### PR TITLE
Feature/add monitoring config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,25 @@ Run using `dotnet`:
 ```sh
 dotnet run
 ```
-Run using `docker`:
+Run using `docker` - runs only the app:
 ```sh
 docker build -t csharp-minitwit .
 docker run -p 5000:8080 csharp-minitwit
 ```
 At this point, the application can be accessed using the link provided in the terminal (http://localhost:5000). Furthermore, API documentation can be accessed at http://localhost:5000/swagger.
+
+Run using `docker-compose` - runs multiple development services, such as Prometheus, Grafana, etc.:
+```sh
+docker-compose up
+```
+
+### Monitoring
+| Service    | Endpoint |
+| -------- | ------- |
+| Built-in metrics  | http://localhost:5000/metrics    |
+| Prometheus | http://localhost:9090     |
+| Grafana    | http://localhost:3000    |
+
 
 #### csharp-minitwit tests
 Tests for `csharp-minitwit` can be run by opening a new terminal and cd into the test folder:

--- a/csharp-minitwit/Program.cs
+++ b/csharp-minitwit/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.OpenApi.Models;
 using csharp_minitwit.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using OpenTelemetry.Metrics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,8 +16,21 @@ builder.Services.Configure<CookiePolicyOptions>(options =>
     options.MinimumSameSitePolicy = SameSiteMode.None;
 });
 
-// Setup logging to console
-builder.Logging.AddConsole();
+// Setup telemetry and monitoring 
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(builder =>
+    {
+        builder.AddPrometheusExporter();
+
+        builder.AddMeter("Microsoft.AspNetCore.Hosting",
+                         "Microsoft.AspNetCore.Server.Kestrel");
+        builder.AddView("http.server.request.duration",
+            new ExplicitBucketHistogramConfiguration
+            {
+                Boundaries = new double[] { 0, 0.005, 0.01, 0.025, 0.05,
+                       0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }
+            });
+    });
 
 builder.Services.AddSession(options =>
 {
@@ -36,13 +50,15 @@ builder.Services.AddSwaggerGen(c =>
         c.IncludeXmlComments(xmlPath);
     });
 
+// Setup logging to console
+builder.Logging.AddConsole();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Home/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 } else {
     app.UseDeveloperExceptionPage();
@@ -50,15 +66,14 @@ if (!app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.MapPrometheusScrapingEndpoint();
+
 // app.UseHttpsRedirection();
 app.UseStaticFiles();
-
 app.UseRouting();
 app.UseSession();
-
 app.UseAuthentication();
 app.UseAuthorization();
-
 app.UseCookiePolicy();
 
 app.MapControllerRoute(

--- a/csharp-minitwit/csharp-minitwit.csproj
+++ b/csharp-minitwit/csharp-minitwit.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="dapper" Version="2.1.28" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="Scriban" Version="5.9.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/csharp-minitwit/docker-compose.yml
+++ b/csharp-minitwit/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+
+networks:
+  main:
+
+services:
+  minitwitimage:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    container_name: csharp-minitwit
+    networks:
+      - main
+    ports:
+      - "5000:8080"
+  
+  prometheus:
+      image: prom/prometheus
+      container_name: prometheus
+      volumes:
+        - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      ports:
+        - "9090:9090"
+      networks:
+        - main
+      # This extra host is the one being scrapped by Prometheus
+      # It is required so the scrapping endpoint is mapped to the name of the app's Docker image name and not to the containers changing ID
+      extra_hosts:
+      - "csharp-minitwit:host-gateway"
+
+  grafana:
+    image: grafana/grafana:10.2.4
+    ports:
+      - "3000:3000"
+    networks:
+      - main

--- a/csharp-minitwit/prometheus.yml
+++ b/csharp-minitwit/prometheus.yml
@@ -1,0 +1,29 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+scrape_configs:
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: 'csharp-minitwit'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["csharp-minitwit:5000"]  ## Port being scrapped, it is to "csharp-minitwit:host-gateway" extra host inside the corresponding docker-compose

--- a/csharp-minitwit/remote_files/docker-compose.yml
+++ b/csharp-minitwit/remote_files/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.8"
 
 networks:
   main:

--- a/log
+++ b/log
@@ -1,9 +1,0 @@
-#Considerations
-##Session02
-- we will be using gitflow branching model: https://nvie.com/posts/a-successful-git-branching-model/
-Recomend to use git rebase instea of git merge into your own branch.
-- c# programming language is selected for refactoring.
-
-Recommended tools:
-- git krakken
-


### PR DESCRIPTION
To run the new monitoring services we can run ```docker-compose up``` from the csharp-minitwit folder.

This spins up the app + Prometheus + Grafana servers. 

App: http://localhost:5000 --> adds a new endpoint /metrics that Prometheus uses to scrap the data.
Prometheus: http://localhost:9090
Grafana: http://localhost:3000

Related comments:
> **docker-compose files refactoring?:**I created a root level docker-compose file since I thought this could be the development environment. Do we need the docker-compose files inside remote_files and preproduction_remote_files? These are not being called, since the ```deployment.yml``` and ```preproduction_deployment.yml``` workflows use the root level Dockerfile. I would suggest keeping the root one, which represents the Development environment, and clean these two. Maybe I am missing something and they are required for some other reason :)  

> **Fix needed?:** the Database connection string for development (when running ```dotnet run``` is broken since we are pointing to ```Data Source=/app/Databases/volume/minitwit.db``` that is required when using Docker, but not accessible when in Development mode (should it be ```Data Source=./Databases/minitwit.db```?). 